### PR TITLE
Add treat_numeric_as_conflict option to prevent ambiguous numeric slugs

### DIFF
--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -12,12 +12,28 @@ module FriendlyId
         return false if @config.reserved_words.include?(slug)
       end
 
+      if @config.treat_numeric_as_conflict && purely_numeric_slug?(slug)
+        return false
+      end
+
       !@scope.exists_by_friendly_id?(slug)
     end
 
     def generate(candidates)
       candidates.each { |c| return c if available?(c) }
       nil
+    end
+
+    private
+
+    def purely_numeric_slug?(slug)
+      return false unless slug
+      begin
+        Integer(slug, 10)
+        slug.to_s == Integer(slug, 10).to_s
+      rescue
+        false
+      end
     end
   end
 end

--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -386,7 +386,7 @@ module FriendlyId
     # {FriendlyId::Configuration FriendlyId::Configuration}.
     module Configuration
       attr_writer :slug_column, :slug_limit, :sequence_separator
-      attr_accessor :slug_generator_class
+      attr_accessor :slug_generator_class, :treat_numeric_as_conflict
 
       # Makes FriendlyId use the slug column for querying.
       # @return String The slug column.

--- a/test/numeric_slug_test.rb
+++ b/test/numeric_slug_test.rb
@@ -1,5 +1,10 @@
 require "helper"
 
+class Article < ActiveRecord::Base
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+end
+
 class NumericSlugTest < TestCaseClass
   include FriendlyId::Test
   include FriendlyId::Test::Shared::Core
@@ -8,24 +13,96 @@ class NumericSlugTest < TestCaseClass
     Article
   end
 
-  test "should generate numeric slugs" do
+  test "should generate numeric slugs by default" do
     transaction do
       record = model_class.create! name: "123"
       assert_equal "123", record.slug
     end
   end
 
-  test "should find by numeric slug" do
+  test "should find by numeric slug by default" do
     transaction do
       record = model_class.create! name: "123"
       assert_equal model_class.friendly.find("123").id, record.id
     end
   end
 
-  test "should exist? by numeric slug" do
+  test "should exist? by numeric slug by default" do
     transaction do
       model_class.create! name: "123"
       assert model_class.friendly.exists?("123")
+    end
+  end
+end
+
+class NumericSlugConflictTest < TestCaseClass
+  include FriendlyId::Test
+
+  class ArticleWithNumericPrevention < ActiveRecord::Base
+    self.table_name = "articles"
+    extend FriendlyId
+    friendly_id :name, use: :slugged
+    friendly_id_config.treat_numeric_as_conflict = true
+  end
+
+  def model_class
+    ArticleWithNumericPrevention
+  end
+
+  test "should prevent purely numeric slugs when treat_numeric_as_conflict is enabled" do
+    transaction do
+      record = model_class.create! name: "123"
+      refute_equal "123", record.slug
+      assert_match(/\A123-[0-9a-f-]{36}\z/, record.slug)
+    end
+  end
+
+  test "should allow non-numeric slugs when treat_numeric_as_conflict is enabled" do
+    transaction do
+      record = model_class.create! name: "abc123"
+      assert_equal "abc123", record.slug
+    end
+  end
+
+  test "should allow alphanumeric slugs when treat_numeric_as_conflict is enabled" do
+    transaction do
+      record = model_class.create! name: "product-123"
+      assert_equal "product-123", record.slug
+    end
+  end
+
+  test "should handle zero as numeric" do
+    transaction do
+      record = model_class.create! name: "0"
+      refute_equal "0", record.slug
+      assert_match(/\A0-[0-9a-f-]{36}\z/, record.slug)
+    end
+  end
+
+  test "should handle large numbers as numeric" do
+    transaction do
+      record = model_class.create! name: "999999999"
+      refute_equal "999999999", record.slug
+      assert_match(/\A999999999-[0-9a-f-]{36}\z/, record.slug)
+    end
+  end
+
+  test "should find records with UUID-suffixed numeric slugs" do
+    transaction do
+      record = model_class.create! name: "123"
+      found = model_class.friendly.find(record.slug)
+      assert_equal record.id, found.id
+    end
+  end
+
+  test "should resolve conflicts between multiple numeric slugs" do
+    transaction do
+      record1 = model_class.create! name: "456"
+      record2 = model_class.create! name: "456"
+
+      refute_equal record1.slug, record2.slug
+      assert_match(/\A456-[0-9a-f-]{36}\z/, record1.slug)
+      assert_match(/\A456-[0-9a-f-]{36}\z/, record2.slug)
     end
   end
 end

--- a/test/numeric_slug_test.rb
+++ b/test/numeric_slug_test.rb
@@ -5,6 +5,13 @@ class Article < ActiveRecord::Base
   friendly_id :name, use: :slugged
 end
 
+class ArticleWithNumericPrevention < ActiveRecord::Base
+  self.table_name = "articles"
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+  friendly_id_config.treat_numeric_as_conflict = true
+end
+
 class NumericSlugTest < TestCaseClass
   include FriendlyId::Test
   include FriendlyId::Test::Shared::Core
@@ -13,45 +20,30 @@ class NumericSlugTest < TestCaseClass
     Article
   end
 
-  test "should generate numeric slugs by default" do
+  test "should generate numeric slugs" do
     transaction do
       record = model_class.create! name: "123"
       assert_equal "123", record.slug
     end
   end
 
-  test "should find by numeric slug by default" do
+  test "should find by numeric slug" do
     transaction do
       record = model_class.create! name: "123"
       assert_equal model_class.friendly.find("123").id, record.id
     end
   end
 
-  test "should exist? by numeric slug by default" do
+  test "should exist? by numeric slug" do
     transaction do
       model_class.create! name: "123"
       assert model_class.friendly.exists?("123")
     end
   end
-end
-
-class NumericSlugConflictTest < TestCaseClass
-  include FriendlyId::Test
-
-  class ArticleWithNumericPrevention < ActiveRecord::Base
-    self.table_name = "articles"
-    extend FriendlyId
-    friendly_id :name, use: :slugged
-    friendly_id_config.treat_numeric_as_conflict = true
-  end
-
-  def model_class
-    ArticleWithNumericPrevention
-  end
 
   test "should prevent purely numeric slugs when treat_numeric_as_conflict is enabled" do
     transaction do
-      record = model_class.create! name: "123"
+      record = ArticleWithNumericPrevention.create! name: "123"
       refute_equal "123", record.slug
       assert_match(/\A123-[0-9a-f-]{36}\z/, record.slug)
     end
@@ -59,46 +51,46 @@ class NumericSlugConflictTest < TestCaseClass
 
   test "should allow non-numeric slugs when treat_numeric_as_conflict is enabled" do
     transaction do
-      record = model_class.create! name: "abc123"
+      record = ArticleWithNumericPrevention.create! name: "abc123"
       assert_equal "abc123", record.slug
     end
   end
 
   test "should allow alphanumeric slugs when treat_numeric_as_conflict is enabled" do
     transaction do
-      record = model_class.create! name: "product-123"
+      record = ArticleWithNumericPrevention.create! name: "product-123"
       assert_equal "product-123", record.slug
     end
   end
 
-  test "should handle zero as numeric" do
+  test "should handle zero as numeric when treat_numeric_as_conflict is enabled" do
     transaction do
-      record = model_class.create! name: "0"
+      record = ArticleWithNumericPrevention.create! name: "0"
       refute_equal "0", record.slug
       assert_match(/\A0-[0-9a-f-]{36}\z/, record.slug)
     end
   end
 
-  test "should handle large numbers as numeric" do
+  test "should handle large numbers as numeric when treat_numeric_as_conflict is enabled" do
     transaction do
-      record = model_class.create! name: "999999999"
+      record = ArticleWithNumericPrevention.create! name: "999999999"
       refute_equal "999999999", record.slug
       assert_match(/\A999999999-[0-9a-f-]{36}\z/, record.slug)
     end
   end
 
-  test "should find records with UUID-suffixed numeric slugs" do
+  test "should find records with UUID-suffixed numeric slugs when treat_numeric_as_conflict is enabled" do
     transaction do
-      record = model_class.create! name: "123"
-      found = model_class.friendly.find(record.slug)
+      record = ArticleWithNumericPrevention.create! name: "123"
+      found = ArticleWithNumericPrevention.friendly.find(record.slug)
       assert_equal record.id, found.id
     end
   end
 
-  test "should resolve conflicts between multiple numeric slugs" do
+  test "should resolve conflicts between multiple numeric slugs when treat_numeric_as_conflict is enabled" do
     transaction do
-      record1 = model_class.create! name: "456"
-      record2 = model_class.create! name: "456"
+      record1 = ArticleWithNumericPrevention.create! name: "456"
+      record2 = ArticleWithNumericPrevention.create! name: "456"
 
       refute_equal record1.slug, record2.slug
       assert_match(/\A456-[0-9a-f-]{36}\z/, record1.slug)


### PR DESCRIPTION
## Summary

This PR adds a new configuration option `treat_numeric_as_conflict` to resolve the ambiguity where `Model.friendly.find("123")` could return either a record with `slug="123"` OR a record with `id=123`.

When enabled, purely numeric slug candidates are treated as conflicts and resolved using UUID suffixing, ensuring all slugs contain non-numeric characters that eliminate lookup ambiguity.

## Changes

- Added `treat_numeric_as_conflict` configuration option to `Slugged::Configuration`  
- Updated `SlugGenerator` to detect and reject purely numeric slugs when enabled
- Added `purely_numeric_slug?` helper method using `Integer()` validation (consistent with `potential_primary_key?`)
- Expanded test coverage for both default behavior and numeric prevention

## Usage

```ruby
class Product < ApplicationRecord
  extend FriendlyId
  friendly_id :name, use: :slugged
  friendly_id_config.treat_numeric_as_conflict = true
end

# Results:
Product.create(name: "123")     # slug: "123-f9f3789a-daec-4156-af1d-fab81aa16ee5"
Product.create(name: "abc123")  # slug: "abc123" (unchanged)
```

## Testing Done

- All existing tests pass
   - Verified backward compatibility (default behavior unchanged)
- Added comprehensive test coverage for new functionality
   - Tests cover edge cases: zero, large numbers, alphanumeric combinations
   - Verified UUID conflict resolution works for multiple numeric slugs

## Deploy Notes

- **No breaking changes**: This is a new opt-in configuration option
- **No migration required**: Uses existing slug storage and UUID conflict resolution
- **Safe to deploy**: Feature is disabled by default, maintaining all existing behavior
- **Rollback safe**: Simply remove configuration option to disable

## Fixes

Addresses the ambiguous lookup issue reported in #276 where `User.find('123-foobar')` could incorrectly return a user with `id=123` instead of searching for the intended slug.